### PR TITLE
Sections and Synopses should no longer be displayed in preview.

### DIFF
--- a/styles/fountain.less
+++ b/styles/fountain.less
@@ -243,14 +243,8 @@ atom-text-editor.editor {
       width: 92.5%;
     }
 
-    p.section {
-      color: #bbb;
-      margin-left: -30px;
-    }
-
-    p.synopsis {
-      color: #bbb;
-      margin-left: -20px;
+    p.section, p.synopsis {
+      display: none;
     }
 
     span.italic {


### PR DESCRIPTION
I used the CSS [display](https://www.w3schools.com/cssref/playit.asp?filename=playcss_display&preval=none) property to make `p.synopsis` and `p.section` disappear in the preview window. This renders the preview more accurate to [the fountain syntax](https://fountain.io/syntax#section-sections).