### PR TITLE
Fix PDF generation paths on Windows.

### DIFF
--- a/lib/fountain-pdf-converter.coffee
+++ b/lib/fountain-pdf-converter.coffee
@@ -65,7 +65,7 @@ class PdfConverter
 
     notifySuccess = () =>
       if !isPreview
-          atom.notifications.addSuccess("New file \"#{fileCommonName}.pdf\" has been created")
+          atom.notifications.addSuccess("New file \"#{parsedPath.name}.pdf\" has been created")
       return Promise.resolve()
 
     deleteTempFile = () =>

--- a/lib/fountain-pdf-converter.coffee
+++ b/lib/fountain-pdf-converter.coffee
@@ -4,37 +4,36 @@ path = require 'path'
 
 class PdfConverter
 
-  createPreview: (projectPath, fileName, fileText) ->
-    @initiateConversion(projectPath, fileName, fileText, true)
+  createPreview: (projectPath, fileText) ->
+    @initiateConversion(projectPath, fileText, true)
 
-  createPdf: (projectPath, fileName, fileText) ->
-    @initiateConversion(projectPath, fileName, fileText)
+  createPdf: (projectPath, fileText) ->
+    @initiateConversion(projectPath, fileText)
 
-  initiateConversion: (projectPath, fileName, fileText, isPreview=false) ->
+  initiateConversion: (projectPath, fileText, isPreview=false) ->
 
-    [fileCommonName, fileExtension] = fileName.split('.')
+    parsedPath = path.parse(projectPath)
 
     #only prompt for save if not temp && overwriting
     if isPreview
-      @toFile(projectPath, fileName, fileText, isPreview)
+      @toFile(parsedPath, fileText, isPreview)
     else
       try
         # make cross-platform for the overwrite check
-        fs.readFileSync("#{projectPath + '/' + fileCommonName}.pdf")
+        fs.readFileSync(path.join(parsedPath.dir, "#{parsedPath.name}.pdf"))
         choice = atom.confirm
           message: "File exists..."
-          detailedMessage: "File #{fileCommonName}.pdf already exists.  Would you like to overwrite?"
+          detailedMessage: "File #{parsedPath.name}.pdf already exists.  Would you like to overwrite?"
           buttons: ["Yes", "No"]
         if choice == 0
-          @toFile(projectPath, fileName, fileText, isPreview)
+          @toFile(parsedPath, fileText, isPreview)
         else
           Promise.resolve()
       catch err
-        @toFile(projectPath, fileName, fileText, isPreview)
+        @toFile(parsedPath, fileText, isPreview)
 
-  toFile: (projectPath, fileName, fileText, isPreview=false) ->
+  toFile: (parsedPath, fileText, isPreview=false) ->
 
-    [fileCommonName, fileExtension] = fileName.split('.')
     timeStamp = new Date().getTime()
 
     # construct paths
@@ -42,14 +41,14 @@ class PdfConverter
     packageTempPath = path.join(packagePath, "temp")
     tempFilePath = path.join(packageTempPath, "tmp#{timeStamp}.fountain")
     afterwritingPath = path.join(packagePath, "node_modules", "afterwriting", "awc.js")
-    outputFullPath = path.join("#{if isPreview then packageTempPath else projectPath}", "#{if isPreview then '(preview) ' else ''}#{fileCommonName}.pdf")
+    outputFullPath = path.join("#{if isPreview then packageTempPath else parsedPath.dir}", "#{if isPreview then '(preview) ' else ''}#{parsedPath.name}.pdf")
     configPath = path.join(packagePath, "configs", "afterwritingConfig.json")
 
     notifyBegin = () =>
       if isPreview
-        atom.notifications.addSuccess("Generating preview for \"#{fileCommonName}.fountain\"")
+        atom.notifications.addSuccess("Generating preview for \"#{parsedPath.name}.fountain\"")
       else
-        atom.notifications.addSuccess("Generating file \"#{fileCommonName}.pdf\"")
+        atom.notifications.addSuccess("Generating file \"#{parsedPath.name}.pdf\"")
       return Promise.resolve()
 
     writeTempFile = () =>

--- a/lib/fountain.coffee
+++ b/lib/fountain.coffee
@@ -85,11 +85,9 @@ module.exports = Fountain =
       activeEditorPath = activeEditor.getPath()
       if !activeEditorPath
         return atom.notifications.addInfo("File must be saved to render PDF preview")
-      projectPath = if event then event.path.replace(/\\/g,'/').split('/') else activeEditorPath.replace(/\\/g,'/').split('/')
-      fileName = projectPath.pop()
       text = activeEditor.getSelectedText() || activeEditor.getText()
       pdfConverter = new PdfConverter()
-      pdfConverter.createPreview(projectPath.join('/'), fileName, text).then (uri) =>
+      pdfConverter.createPreview((if event then event.path else activeEditorPath), text).then (uri) =>
         atom.workspace.open(uri, {"searchAllPanes":true})
         if !event then activeEditor.onDidSave(this.pdfPreview)
     else
@@ -101,11 +99,9 @@ module.exports = Fountain =
       activeEditorPath = activeEditor.getPath()
       if !activeEditorPath
         return atom.notifications.addInfo("File must be saved to export PDF")
-      projectPath = activeEditorPath.replace(/\\/g,'/').split('/')
-      fileName = projectPath.pop()
       text = activeEditor.getSelectedText() || activeEditor.getText()
       pdfConverter = new PdfConverter()
-      pdfConverter.createPdf(projectPath.join('/'), fileName, text).then (uri) ->
+      pdfConverter.createPdf(activeEditorPath, text).then (uri) ->
         if uri then atom.workspace.open(uri, {"searchAllPanes":true})
     else
       atom.notifications.addInfo("No fountain file is currently targeted")

--- a/lib/fountain.coffee
+++ b/lib/fountain.coffee
@@ -85,7 +85,7 @@ module.exports = Fountain =
       activeEditorPath = activeEditor.getPath()
       if !activeEditorPath
         return atom.notifications.addInfo("File must be saved to render PDF preview")
-      projectPath = if event then event.path.split('/') else activeEditorPath.split('/')
+      projectPath = if event then event.path.replace(/\\/g,'/').split('/') else activeEditorPath.replace(/\\/g,'/').split('/')
       fileName = projectPath.pop()
       text = activeEditor.getSelectedText() || activeEditor.getText()
       pdfConverter = new PdfConverter()
@@ -101,7 +101,7 @@ module.exports = Fountain =
       activeEditorPath = activeEditor.getPath()
       if !activeEditorPath
         return atom.notifications.addInfo("File must be saved to export PDF")
-      projectPath = activeEditorPath.split('/')
+      projectPath = activeEditorPath.replace(/\\/g,'/').split('/')
       fileName = projectPath.pop()
       text = activeEditor.getSelectedText() || activeEditor.getText()
       pdfConverter = new PdfConverter()

--- a/spec/fountain-outline-view-spec.coffee
+++ b/spec/fountain-outline-view-spec.coffee
@@ -1,9 +1,10 @@
 FountainOutlineView = require '../lib/fountain-outline-view'
 fs = require 'fs'
 _ = require 'underscore-plus'
+path = require 'path'
 
 describe 'Fountain Outline View', ->
-  
+
   SCENE_LIST = [ { line : 12, title : "EXT. BRICK'S PATIO - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 52, title : "INT. TRAILER HOME - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 69, title : "EXT. BRICK'S POOL - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 80, title : ".SNIPER SCOPE POV", type : "scene", hasNote : false, depth : 0 }, { line : 95, title : ".OPENING TITLES", type : "scene", hasNote : false, depth : 0 }, { line : 105, title : "EXT. WOODEN SHACK - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 129, title : "INT. GARAGE - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 144, title : "EXT. PALATIAL MANSION - DAY", type : "scene", hasNote : false, depth : 0 } ]
   FORMATTED_SCENE_LIST = '<li class="outline-item scene depth-0" data-line="12"><span class="icon icon-text">EXT. BRICK\'S PATIO - DAY</span></li><li class="outline-item scene depth-0" data-line="52"><span class="icon icon-text">INT. TRAILER HOME - DAY</span></li><li class="outline-item scene depth-0" data-line="69"><span class="icon icon-text">EXT. BRICK\'S POOL - DAY</span></li><li class="outline-item scene depth-0" data-line="80"><span class="icon icon-text">.SNIPER SCOPE POV</span></li><li class="outline-item scene depth-0" data-line="95"><span class="icon icon-text">.OPENING TITLES</span></li><li class="outline-item scene depth-0" data-line="105"><span class="icon icon-text">EXT. WOODEN SHACK - DAY</span></li><li class="outline-item scene depth-0" data-line="129"><span class="icon icon-text">INT. GARAGE - DAY</span></li><li class="outline-item scene depth-0" data-line="144"><span class="icon icon-text">EXT. PALATIAL MANSION - DAY</span></li>'
   SCENE_TYPE_LIST = _.where(SCENE_LIST, {type: 'scene'} )
@@ -25,7 +26,8 @@ describe 'Fountain Outline View', ->
 
     beforeEach ->
       @fov = new FountainOutlineView()
-      fileToRead = 'spec/test_files/outline-view-tests.fountain'
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-tests.fountain')
       @fileText = fs.readFileSync(fileToRead, 'utf8')
 
     it 'should have text', ->
@@ -49,7 +51,8 @@ describe 'Fountain Outline View', ->
 
     beforeEach ->
       @fov = new FountainOutlineView()
-      fileToRead = 'spec/test_files/outline-view-tests.fountain'
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-tests.fountain')
       @fileText = fs.readFileSync(fileToRead, 'utf8')
       @fileLines = @fileText.split('\n')
 
@@ -144,7 +147,8 @@ describe 'Fountain Outline View', ->
 
     beforeEach ->
       @fov = new FountainOutlineView()
-      fileToRead = 'spec/test_files/outline-view-tests.fountain'
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-tests.fountain')
       @fileText = fs.readFileSync(fileToRead, 'utf8')
       @fileLines = @fileText.split('\n')
 
@@ -167,4 +171,3 @@ describe 'Fountain Outline View', ->
 
     it 'should be able to flatten massive nested scene list', ->
       expect(@fov.flatten(NESTED_SCENE_LIST, [])).toEqual(FLATTENED_SCENE_LIST)
-

--- a/spec/fountain-pdf-converter-spec.coffee
+++ b/spec/fountain-pdf-converter-spec.coffee
@@ -1,5 +1,6 @@
 PdfConverter = require '../lib/fountain-pdf-converter'
 fs = require 'fs'
+path = require 'path'
 
 describe 'Fountain PDF Converter', ->
 
@@ -23,12 +24,13 @@ describe 'Fountain PDF Converter', ->
     it 'should be able to save new pdf', ->
       spyOn(atom.notifications, 'addError')
       spyOn(atom.notifications, 'addSuccess')
-      fileName = 'grammar-tests.fountain'
-      pdfName = 'grammar-tests.pdf'
-      fileContent = fs.readFileSync('./spec/test_files/' + fileName, "utf8")
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileName = path.join(packagePath, 'spec/test_files/grammar-tests.fountain')
+      pdfName = path.join(packagePath, 'spec/test_files/grammar-tests.pdf')
+      fileContent = fs.readFileSync(fileName, "utf8")
 
       runs () ->
-        @pdfConverter.toFile("./", 'grammar-tests.fountain', fileContent).then () ->
+        @pdfConverter.toFile(path.parse(fileName), fileContent).then () ->
           flag = true
       , 5000
 
@@ -56,12 +58,13 @@ describe 'Fountain PDF Converter', ->
       spyOn(atom.notifications, 'addError')
       spyOn(atom.notifications, 'addSuccess')
       spyOn(atom, "confirm")
-      fileName = 'grammar-tests.fountain'
-      pdfName = 'grammar-tests.pdf'
-      fileContent = fs.readFileSync('./spec/test_files/' + fileName, "utf8")
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileName = path.join(packagePath, 'spec/test_files/grammar-tests.fountain')
+      pdfName = path.join(packagePath, 'spec/test_files/grammar-tests.pdf')
+      fileContent = fs.readFileSync(fileName, "utf8")
 
       runs () ->
-        @pdfConverter.initiateConversion("./", 'grammar-tests.fountain', fileContent).then () ->
+        @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
       , 5000
 
@@ -80,12 +83,13 @@ describe 'Fountain PDF Converter', ->
       spyOn(atom.notifications, 'addError')
       spyOn(atom.notifications, 'addSuccess')
       spyOn(atom, "confirm").andReturn(1)
-      fileName = 'grammar-tests.fountain'
-      pdfName = 'grammar-tests.pdf'
-      fileContent = fs.readFileSync('./spec/test_files/' + fileName, "utf8")
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileName = path.join(packagePath, 'spec/test_files/grammar-tests.fountain')
+      pdfName = path.join(packagePath, 'spec/test_files/grammar-tests.pdf')
+      fileContent = fs.readFileSync(fileName, "utf8")
 
       runs () ->
-        @pdfConverter.initiateConversion("./", 'grammar-tests.fountain', fileContent).then () ->
+        @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
       , 5000
 
@@ -104,11 +108,12 @@ describe 'Fountain PDF Converter', ->
       spyOn(atom.notifications, 'addError')
       spyOn(atom.notifications, 'addSuccess')
       spyOn(atom, "confirm").andReturn(0)
-      fileName = 'grammar-tests.fountain'
-      pdfName = 'grammar-tests.pdf'
-      fileContent = fs.readFileSync('./spec/test_files/' + fileName, "utf8")
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileName = path.join(packagePath, 'spec/test_files/grammar-tests.fountain')
+      pdfName = path.join(packagePath, 'spec/test_files/grammar-tests.pdf')
+      fileContent = fs.readFileSync(fileName, "utf8")
       runs () ->
-        @pdfConverter.initiateConversion("./", 'grammar-tests.fountain', fileContent).then () ->
+        @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
       , 5000
 


### PR DESCRIPTION
Paths being sent to `createPDF` and `createPreview` were not split correctly due to windows paths having backslashes instead of forward slashes. This resulted in `projectPath` being empty and `fileName` containing the entire path. With these values `createPDF` still functioned for the most part as expected, but `createPreview` would fail completely.