### PR TITLE
Outline Reorder Nested Elements

### DIFF
--- a/lib/fountain-outline-view.coffee
+++ b/lib/fountain-outline-view.coffee
@@ -76,12 +76,15 @@ class FountainOutlineView extends ScrollView
         @editor.setCursorBufferPosition(position)
         @editor.moveToFirstCharacterOfLine()
 
+    @scenesHidden ||= false
+    @setSceneHiddenState()
     showScenesHandler = $("#showScenesCheckbox")
-      .on 'click', (e) ->
+      .on 'click', (e) =>
         if e.currentTarget.checked
-          $('li.scene').hide()
+          @scenesHidden = true
         else
-          $('li.scene').show()
+          @scenesHidden = false
+        @setSceneHiddenState()
 
     sortable.option("disabled", @outlineLocked)
     @setOutlineLockIconState()
@@ -100,6 +103,12 @@ class FountainOutlineView extends ScrollView
   clearEventHandlers: () ->
     _.each(@eventHandlers, (handler) -> handler.off())
     @eventHandlers = []
+
+  setSceneHiddenState: () =>
+    if (@scenesHidden)
+      $('li.scene').hide()
+    else
+      $('li.scene').show()
 
   setOutlineLockIconState: () =>
     if (@outlineLocked)

--- a/lib/fountain-outline-view.coffee
+++ b/lib/fountain-outline-view.coffee
@@ -149,6 +149,9 @@ class FountainOutlineView extends ScrollView
     while i < scenes.length
       nextSiblingLine
 
+      # supports drag drop when scenes hidden
+      scenes[i].parentEndline = nextParentSiblingLine
+
       # last element
       if i == scenes.length - 1
         nextSiblingLine = nextParentSiblingLine
@@ -272,11 +275,27 @@ class FountainOutlineView extends ScrollView
 
   getNewStartLineIndex: (oldFileLines, sceneList, oldIndex, newIndex) =>
     newStartLine = null
+
     # account for array index changes
     if (newIndex > oldIndex)
       newIndex += 1
+
     if (sceneList[newIndex])
-      newStartLine = parseInt(sceneList[newIndex].line)
+
+      if (@scenesHidden)
+        # if the transition is to
+        #   the first position in the script
+        #     or
+        #   the first position under a parent
+        if (sceneList[newIndex].type != 'scene' && (!sceneList[newIndex-1] || sceneList[newIndex-1].endline == sceneList[newIndex].parentEndline))
+          newStartLine = parseInt(sceneList[newIndex].line)
+        else
+          # index to the parent to place after all children
+          newStartLine = parseInt(sceneList[newIndex-1].endline)
+
+      else
+        newStartLine = parseInt(sceneList[newIndex].line)
+
     else
       # they can manage any newline gaps
       newStartLine = oldFileLines.length - 1

--- a/lib/fountain-outline-view.coffee
+++ b/lib/fountain-outline-view.coffee
@@ -236,30 +236,25 @@ class FountainOutlineView extends ScrollView
     oldStartLine = null
     oldEndLine = null
 
+    @onChoose = (evt) =>
+      [oldStartLine, oldEndLine] = @getOldLineIndexes(oldFileLines, sceneList, evt)
+
+    @onUpdate = (evt) =>
+      oldIndex = evt.oldIndex
+      newIndex = evt.newIndex
+      newLineFallsWithinOwnBounds = sceneList[newIndex].line > sceneList[oldIndex].line && sceneList[newIndex].line < sceneList[oldIndex].endline
+      if (!newLineFallsWithinOwnBounds)
+        # element moved, so generate new buffer contents #
+        newStartLine = @getNewStartLineIndex(oldFileLines, sceneList, oldIndex, newIndex)
+        newFileText = @getNewFileText(oldFileLines, oldStartLine, oldEndLine, newStartLine)
+        @setActiveEditorBuffer(newFileText)
+      else
+        # update view manually since nothing changed
+        @updateList()
+
     sortable = Sortable.create(outlineElement, {
-
-      onChoose: (evt) =>
-        [oldStartLine, oldEndLine] = @getOldLineIndexes(oldFileLines, sceneList, evt)
-
-      onUpdate: (evt) =>
-
-        oldIndex = evt.oldIndex
-        newIndex = evt.newIndex
-
-        newLineFallsWithinOwnBounds = sceneList[newIndex].line > sceneList[oldIndex].line && sceneList[newIndex].line < sceneList[oldIndex].endline
-
-        if (!newLineFallsWithinOwnBounds)
-
-          # element moved, so generate new buffer contents #
-          newStartLine = @getNewStartLineIndex(oldFileLines, sceneList, oldIndex, newIndex)
-          newFileText = @getNewFileText(oldFileLines, oldStartLine, oldEndLine, newStartLine)
-          @setActiveEditorBuffer(newFileText)
-
-        else
-
-          # update view manually since nothing changed
-          @updateList()
-
+      onChoose: @onChoose
+      onUpdate: @onUpdate
     })
     sortable
 
@@ -335,4 +330,5 @@ class FountainOutlineView extends ScrollView
 
   setActiveEditorBuffer: (newFileText) =>
     if editor = atom.workspace.getActiveTextEditor()
-      editor.setText(newFileText)
+      @editor = editor
+      @editor.setText(newFileText)

--- a/lib/fountain-outline-view.coffee
+++ b/lib/fountain-outline-view.coffee
@@ -237,9 +237,11 @@ class FountainOutlineView extends ScrollView
     oldEndLine = null
 
     @onChoose = (evt) =>
+#      console.debug("onChoose", evt.oldIndex)
       [oldStartLine, oldEndLine] = @getOldLineIndexes(oldFileLines, sceneList, evt)
 
     @onUpdate = (evt) =>
+#      console.debug("onUpdate", evt.oldIndex, evt.newIndex)
       oldIndex = evt.oldIndex
       newIndex = evt.newIndex
       newLineFallsWithinOwnBounds = sceneList[newIndex].line > sceneList[oldIndex].line && sceneList[newIndex].line < sceneList[oldIndex].endline
@@ -272,6 +274,7 @@ class FountainOutlineView extends ScrollView
     # grab details about scene before array mutates
     oldStartLine = parseInt(movingElement.item.attributes[1].value)
     oldEndLine = parseInt(movingElement.item.attributes[2].value)
+#    console.debug("getOldIndexLines", oldStartLine, oldEndLine)
     [oldStartLine, oldEndLine]
 
   getNewStartLineIndex: (oldFileLines, sceneList, oldIndex, newIndex) =>

--- a/spec/fountain-outline-view-nested-reorder-spec.coffee
+++ b/spec/fountain-outline-view-nested-reorder-spec.coffee
@@ -1,0 +1,152 @@
+FountainOutlineView = require '../lib/fountain-outline-view'
+fs = require 'fs'
+_ = require 'underscore-plus'
+path = require 'path'
+
+describe 'Fountain Outline View Nested Reorder', ->
+
+  beforeEach ->
+    # Ensure you're language package is loaded
+    waitsForPromise ->
+      atom.packages.activatePackage 'fountain'
+
+  # sanity checks
+  it 'should have loaded fountain package', ->
+    expect(atom.packages.isPackageActive('fountain')).toBeTruthy()
+
+  describe 'generating scene list representations', ->
+
+    @fov
+    @fileText
+    @fileLines
+
+    beforeEach ->
+      @fov = new FountainOutlineView()
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-nested-reorder-tests.fountain')
+      @fileText = fs.readFileSync(fileToRead, 'utf8')
+
+    it 'should be able to get scene list', ->
+      # this serves as a sanity check for the following tests
+      sceneList = @fov.findScenes(@fileText)
+      expect(sceneList.length).toBe(4)
+      sceneListFlat = []
+      @fov.flatten(sceneList, sceneListFlat)
+      expect(sceneListFlat.length).toBe(15)
+
+  describe 'getting list (preparation test for the following tests)', ->
+
+    @fov
+    @fileText
+    @fileLines
+    @sceneList
+    @sceneListFlat
+
+    beforeEach ->
+      @fov = new FountainOutlineView()
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-nested-reorder-tests.fountain')
+      @fileText = fs.readFileSync(fileToRead, 'utf8')
+      @sceneList = @fov.findScenes(@fileText)
+      @sceneListFlat = []
+      @fov.flatten(@sceneList, @sceneListFlat)
+
+    it 'should be able to get scene list', ->
+      # this serves as a sanity check for the following tests
+      sceneList = @fov.findScenes(@fileText)
+      expect(sceneList.length).toBe(4)
+      sceneListFlattened = []
+      @fov.flatten(sceneList, sceneListFlattened)
+      expect(sceneListFlattened.length).toBe(15)
+
+  describe 'sibling and parent reordering', ->
+
+    @fov
+    @editor
+    @fileText
+    @sceneList
+    @sceneListFlat
+
+    beforeEach ->
+      packagePath = atom.packages.resolvePackagePath('fountain')
+      fileToRead = path.join(packagePath, 'spec/test_files/outline-view-nested-reorder-tests.fountain')
+      @fileText = fs.readFileSync(fileToRead, 'utf8')
+
+      @fov = new FountainOutlineView()
+      @fov.initialize()
+      @sceneList = @fov.findScenes(@fileText)
+      @sceneListFlat = []
+      @fov.flatten(@sceneList, @sceneListFlat)
+
+      # runs the views update logic as well as updated test index refs
+      @updateState = () =>
+        @fov.updateList()
+        @sceneListFlat = @fov.flatten(@fov.findScenes(@fov.editor.getText()), [])
+
+      # simulates onChoose call
+      @dragScene = (index) =>
+        simulatedEvent = {item: {attributes: [null, {value: @sceneListFlat[index].line}, {value: @sceneListFlat[index].endline}]}}
+        @fov.onChoose(simulatedEvent)
+
+      # simulates onUpdate call
+      @dropScene = (oldIndex, newIndex) =>
+        simulatedEvent = {oldIndex: oldIndex, newIndex: newIndex}
+        @fov.onUpdate(simulatedEvent)
+
+      # simulates drag/drop of a scene
+      @moveScene = (fromIndex, toIndex) =>
+        @dragScene(fromIndex)
+        @dropScene(fromIndex, toIndex)
+
+      waitsForPromise =>
+        atom.workspace.open(fileToRead, {changeFocus: true}).then (e) =>
+          @fov.editor = e
+          @fov.outlineLocked = false
+          @fov.updateList()
+
+      ul = document.createElement('ul')
+      ul.className = "outline-ul"
+      document.getElementsByTagName('body')[0].appendChild(ul)
+      document.getElementsByClassName("outline-ul")[0].appendChild(document.createRange().createContextualFragment(@fov.list))
+
+    it 'should be able to swap siblings', ->
+      @moveScene(6, 4)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(6, 4)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+      @updateState()
+      @moveScene(6, 4)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+
+    it 'should be able to swap sibling headings', ->
+      @updateState()
+      @moveScene(8, 2)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(4, 2)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to swap sibling headings with hidden scenes', ->
+      @updateState()
+      @moveScene(8, 2)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @fov.scenesHidden = true
+      @updateState()
+      @moveScene(4, 2)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+      @fov.scenesHidden = false
+
+    it 'should be able to swap top level acts', ->
+      @updateState()
+      @moveScene(12, 0)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(0, 11)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+

--- a/spec/fountain-outline-view-nested-reorder-spec.coffee
+++ b/spec/fountain-outline-view-nested-reorder-spec.coffee
@@ -59,7 +59,7 @@ describe 'Fountain Outline View Nested Reorder', ->
       @fov.flatten(sceneList, sceneListFlattened)
       expect(sceneListFlattened.length).toBe(15)
 
-  describe 'sibling and parent reordering', ->
+  describe 'nested reordering', ->
 
     @fov
     @editor
@@ -72,16 +72,16 @@ describe 'Fountain Outline View Nested Reorder', ->
       fileToRead = path.join(packagePath, 'spec/test_files/outline-view-nested-reorder-tests.fountain')
       @fileText = fs.readFileSync(fileToRead, 'utf8')
 
+      # initialize typical view state
       @fov = new FountainOutlineView()
       @fov.initialize()
       @sceneList = @fov.findScenes(@fileText)
-      @sceneListFlat = []
-      @fov.flatten(@sceneList, @sceneListFlat)
+      @sceneListFlat = _.reject(@fov.flatten(@sceneList, []), _.matches({type: "synopsis"}))
 
       # runs the views update logic as well as updated test index refs
       @updateState = () =>
         @fov.updateList()
-        @sceneListFlat = @fov.flatten(@fov.findScenes(@fov.editor.getText()), [])
+        @sceneListFlat = _.reject(@fov.flatten(@fov.findScenes(@fov.editor.getText()), []), _.matches({type: "synopsis"}))
 
       # simulates onChoose call
       @dragScene = (index) =>
@@ -98,26 +98,28 @@ describe 'Fountain Outline View Nested Reorder', ->
         @dragScene(fromIndex)
         @dropScene(fromIndex, toIndex)
 
+      # load up editor
       waitsForPromise =>
         atom.workspace.open(fileToRead, {changeFocus: true}).then (e) =>
           @fov.editor = e
           @fov.outlineLocked = false
           @fov.updateList()
 
+      # load up DOM for sortablejs
       ul = document.createElement('ul')
       ul.className = "outline-ul"
       document.getElementsByTagName('body')[0].appendChild(ul)
       document.getElementsByClassName("outline-ul")[0].appendChild(document.createRange().createContextualFragment(@fov.list))
 
     it 'should be able to swap siblings', ->
-      @moveScene(6, 4)
+      @moveScene(6, 5)
       expect(@fov.editor.getText()).not.toEqual(@fileText)
       expect(@fov.editor.getText().length).toEqual(@fileText.length)
       @updateState()
-      @moveScene(6, 4)
+      @moveScene(6, 5)
       expect(@fov.editor.getText()).toEqual(@fileText)
       @updateState()
-      @moveScene(6, 4)
+      @moveScene(6, 5)
       expect(@fov.editor.getText()).not.toEqual(@fileText)
       expect(@fov.editor.getText().length).toEqual(@fileText.length)
 
@@ -127,17 +129,17 @@ describe 'Fountain Outline View Nested Reorder', ->
       expect(@fov.editor.getText()).not.toEqual(@fileText)
       expect(@fov.editor.getText().length).toEqual(@fileText.length)
       @updateState()
-      @moveScene(4, 2)
+      @moveScene(2, 8)
       expect(@fov.editor.getText()).toEqual(@fileText)
 
-    it 'should be able to swap sibling headings with hidden scenes', ->
+    it 'should be able to swap sibling headings with hidden scenes w/o adoption', ->
       @updateState()
-      @moveScene(8, 2)
+      @moveScene(7, 2)
       expect(@fov.editor.getText()).not.toEqual(@fileText)
       expect(@fov.editor.getText().length).toEqual(@fileText.length)
       @fov.scenesHidden = true
       @updateState()
-      @moveScene(4, 2)
+      @moveScene(2, 3)
       expect(@fov.editor.getText()).toEqual(@fileText)
       @fov.scenesHidden = false
 
@@ -147,6 +149,137 @@ describe 'Fountain Outline View Nested Reorder', ->
       expect(@fov.editor.getText()).not.toEqual(@fileText)
       expect(@fov.editor.getText().length).toEqual(@fileText.length)
       @updateState()
-      @moveScene(0, 11)
+      @moveScene(0, 12)
       expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to adopt/give up children', ->
+      @updateState()
+      # adopt
+      @moveScene(7, 3)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      # give up
+      @moveScene(2, 3)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      # to original
+      @moveScene(2, 7)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to have children move under sibling', ->
+      @updateState()
+      @moveScene(6, 7)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(7, 6)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to have children move under parent', ->
+      @updateState()
+      @moveScene(6, 2)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(2, 6)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to have children move under grandparent', ->
+      @updateState()
+      @moveScene(3, 1)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(1, 3)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move heading between acts', ->
+      @updateState()
+      @moveScene(1, 11)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(4, 1)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move sub-heading between headings', ->
+      @updateState()
+      @moveScene(2, 9)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(5, 2)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move scene element to first position', ->
+      @updateState()
+      @moveScene(6, 13)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(13, 6)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move scene element to final position', ->
+      @updateState()
+      @moveScene(6, 13)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(13, 6)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move empty heading element to first position', ->
+      @updateState()
+      @moveScene(7, 0)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(0, 7)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move empty heading element to final position', ->
+      @updateState()
+      @moveScene(7, 13)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(13, 7)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move populated heading element to first position', ->
+      @updateState()
+      @moveScene(2, 0)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(0, 6)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should be able to move populated heading element to final position', ->
+      @updateState()
+      @moveScene(2, 13)
+      expect(@fov.editor.getText()).not.toEqual(@fileText)
+      expect(@fov.editor.getText().length).toEqual(@fileText.length)
+      @updateState()
+      @moveScene(9, 2)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should NOT be able to move parent into self', ->
+      @updateState()
+      @moveScene(2, 4)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should NOT be able to move parent under child', ->
+      @updateState()
+      @moveScene(1, 4)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
+    it 'should NOT be able to move parent under grandchild', ->
+      @updateState()
+      @moveScene(0, 4)
+      expect(@fov.editor.getText()).toEqual(@fileText)
+
 

--- a/spec/fountain-outline-view-spec.coffee
+++ b/spec/fountain-outline-view-spec.coffee
@@ -5,8 +5,8 @@ path = require 'path'
 
 describe 'Fountain Outline View', ->
 
-  SCENE_LIST = [ { line : 12, title : "EXT. BRICK'S PATIO - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 52, title : "INT. TRAILER HOME - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 69, title : "EXT. BRICK'S POOL - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 80, title : ".SNIPER SCOPE POV", type : "scene", hasNote : false, depth : 0 }, { line : 95, title : ".OPENING TITLES", type : "scene", hasNote : false, depth : 0 }, { line : 105, title : "EXT. WOODEN SHACK - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 129, title : "INT. GARAGE - DAY", type : "scene", hasNote : false, depth : 0 }, { line : 144, title : "EXT. PALATIAL MANSION - DAY", type : "scene", hasNote : false, depth : 0 } ]
-  FORMATTED_SCENE_LIST = '<li class="outline-item scene depth-0" data-line="12"><span class="icon icon-text">EXT. BRICK\'S PATIO - DAY</span></li><li class="outline-item scene depth-0" data-line="52"><span class="icon icon-text">INT. TRAILER HOME - DAY</span></li><li class="outline-item scene depth-0" data-line="69"><span class="icon icon-text">EXT. BRICK\'S POOL - DAY</span></li><li class="outline-item scene depth-0" data-line="80"><span class="icon icon-text">.SNIPER SCOPE POV</span></li><li class="outline-item scene depth-0" data-line="95"><span class="icon icon-text">.OPENING TITLES</span></li><li class="outline-item scene depth-0" data-line="105"><span class="icon icon-text">EXT. WOODEN SHACK - DAY</span></li><li class="outline-item scene depth-0" data-line="129"><span class="icon icon-text">INT. GARAGE - DAY</span></li><li class="outline-item scene depth-0" data-line="144"><span class="icon icon-text">EXT. PALATIAL MANSION - DAY</span></li>'
+  SCENE_LIST = [{"line":12,"title":"EXT. BRICK\'S PATIO - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":52},{"line":52,"title":"INT. TRAILER HOME - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":69},{"line":69,"title":"EXT. BRICK\'S POOL - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":80},{"line":80,"title":".SNIPER SCOPE POV","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":95},{"line":95,"title":".OPENING TITLES","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":105},{"line":105,"title":"EXT. WOODEN SHACK - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":129},{"line":129,"title":"INT. GARAGE - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":144},{"line":144,"title":"EXT. PALATIAL MANSION - DAY","type":"scene","hasNote":false,"depth":0,"parentEndline":161,"endline":161}]
+  FORMATTED_SCENE_LIST = '<li class="outline-item scene depth-0" data-line="12" end-line="52"><span class="icon icon-text">EXT. BRICK\'S PATIO - DAY</span></li><li class="outline-item scene depth-0" data-line="52" end-line="69"><span class="icon icon-text">INT. TRAILER HOME - DAY</span></li><li class="outline-item scene depth-0" data-line="69" end-line="80"><span class="icon icon-text">EXT. BRICK\'S POOL - DAY</span></li><li class="outline-item scene depth-0" data-line="80" end-line="95"><span class="icon icon-text">.SNIPER SCOPE POV</span></li><li class="outline-item scene depth-0" data-line="95" end-line="105"><span class="icon icon-text">.OPENING TITLES</span></li><li class="outline-item scene depth-0" data-line="105" end-line="129"><span class="icon icon-text">EXT. WOODEN SHACK - DAY</span></li><li class="outline-item scene depth-0" data-line="129" end-line="144"><span class="icon icon-text">INT. GARAGE - DAY</span></li><li class="outline-item scene depth-0" data-line="144" end-line="161"><span class="icon icon-text">EXT. PALATIAL MANSION - DAY</span></li>'
   SCENE_TYPE_LIST = _.where(SCENE_LIST, {type: 'scene'} )
 
   beforeEach ->
@@ -58,7 +58,7 @@ describe 'Fountain Outline View', ->
 
     it 'should be able to get oldLineIndexes', ->
       # mocking first scene initial drag event
-      mockedMovingElement = {oldIndex: 0, newIndex: undefined, item: attributes: [null, {value: "12"}, null]}
+      mockedMovingElement = {oldIndex: 0, newIndex: undefined, item: attributes: [null, {value: "12"}, {value: "52"}]}
       [startLine, endLine] = @fov.getOldLineIndexes(@fileLines, SCENE_TYPE_LIST, mockedMovingElement)
       expect(startLine).toEqual(12)
       expect(endLine).toEqual(52)
@@ -66,7 +66,7 @@ describe 'Fountain Outline View', ->
     it 'should be able to get oldLineIndexes for last scene', ->
       # mocking first scene initial drag event
       linesInFile = 161
-      mockedMovingElement = {oldIndex: 7, newIndex: undefined, item: attributes: [null, {value: "144"}, null]}
+      mockedMovingElement = {oldIndex: 7, newIndex: undefined, item: attributes: [null, {value: "144"}, {value: "161"}]}
       [startLine, endLine] = @fov.getOldLineIndexes(@fileLines, SCENE_TYPE_LIST, mockedMovingElement)
       expect(startLine).toEqual(144)
       expect(endLine).toEqual(linesInFile)
@@ -81,7 +81,7 @@ describe 'Fountain Outline View', ->
       expect(startLine).toEqual(129)
 
     it 'should be able to get newStartLineIndex at last index', ->
-      lastIndexInFileArray = 160
+      lastIndexInFileArray = 161
       startLine = @fov.getNewStartLineIndex(@fileLines, SCENE_TYPE_LIST, 5, 7)
       expect(startLine).toEqual(lastIndexInFileArray)
 

--- a/spec/fountain-pdf-converter-spec.coffee
+++ b/spec/fountain-pdf-converter-spec.coffee
@@ -15,6 +15,7 @@ describe 'Fountain PDF Converter', ->
 
   describe 'conversion paths', ->
 
+    asyncMaxWaitTime = 5000
     flag = false
 
     beforeEach ->
@@ -32,11 +33,11 @@ describe 'Fountain PDF Converter', ->
       runs () ->
         @pdfConverter.toFile(path.parse(fileName), fileContent).then () ->
           flag = true
-      , 5000
+      , asyncMaxWaitTime
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         fileBuffer = fs.readFileSync(pdfName)
@@ -49,7 +50,7 @@ describe 'Fountain PDF Converter', ->
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         expect(() -> fs.readFileSync(pdfName)).toThrow()
@@ -66,11 +67,11 @@ describe 'Fountain PDF Converter', ->
       runs () ->
         @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
-      , 5000
+      , asyncMaxWaitTime
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         fileBuffer = fs.readFileSync(pdfName)
@@ -91,11 +92,11 @@ describe 'Fountain PDF Converter', ->
       runs () ->
         @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
-      , 5000
+      , asyncMaxWaitTime
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         fileBuffer = fs.readFileSync(pdfName)
@@ -115,11 +116,11 @@ describe 'Fountain PDF Converter', ->
       runs () ->
         @pdfConverter.initiateConversion(fileName, fileContent).then () ->
           flag = true
-      , 5000
+      , asyncMaxWaitTime
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         fileBuffer = fs.readFileSync(pdfName)
@@ -132,7 +133,7 @@ describe 'Fountain PDF Converter', ->
 
       waitsFor () ->
         return flag
-      , "flag set", 3000
+      , "flag set", asyncMaxWaitTime
 
       runs () ->
         expect(() -> fs.readFileSync(pdfName)).toThrow()

--- a/spec/test_files/outline-view-nested-reorder-tests.fountain
+++ b/spec/test_files/outline-view-nested-reorder-tests.fountain
@@ -1,0 +1,39 @@
+Title:	**Reorder Tester**
+Credit:	Written by
+Author:	Jesse Bostic
+Draft date:	12/17/2017
+
+# ACT I
+
+## Heading 1
+= Synopsis 1
+
+### Sub Heading 1.1
+
+INT. Jesse's Computer Room
+
+JESSE
+I have to figure out these tests for the atom fountain plugin...
+
+INT. Outside Jesse's Computer Room
+
+JESSE
+(muffled screams)
+
+EXT. Outside of Jesse's house
+
+Loud explosion is heard from inside the home; birds flying from nearby trees; neighbor dogs barking.
+
+EXT. Above Jesse's House
+
+Firetrucks and ambulances arrive and begin sectioning off the area.
+
+### Subheading 1.2
+### Subheading 1.3
+
+## Heading 2
+## Heading 3
+
+# ACT II
+# ACT III
+# ACT IV


### PR DESCRIPTION
Rules:
1) Parent cannot be moved into its self or own child/grandchild/etc.
2) Movement of parent under a sibling will adopt sibling's trailing child/grandchild/etc. (post insertion point)
3) Synopsis elements are not individually movable

Supported:
1) Movement of elements among all positions equivalent in hierarchy
2) When scenes are hidden, child scenes are considered a part of their parent heading