### PR TITLE
Configure PDF Output

### DIFF
--- a/lib/fountain-pdf-config-generator.coffee
+++ b/lib/fountain-pdf-config-generator.coffee
@@ -1,4 +1,3 @@
-{BufferedNodeProcess} = require 'atom'
 fs = require 'fs'
 path = require 'path'
 _ = require 'underscore-plus'

--- a/lib/fountain-pdf-config-generator.coffee
+++ b/lib/fountain-pdf-config-generator.coffee
@@ -1,0 +1,26 @@
+{BufferedNodeProcess} = require 'atom'
+fs = require 'fs'
+path = require 'path'
+_ = require 'underscore-plus'
+
+class PdfConfigGenerator
+
+  createConfig: () ->
+
+    packagePath = atom.packages.resolvePackagePath('fountain')
+    configPath = path.join(packagePath, "configs", "afterwritingConfig.json")
+
+    configs = atom.config.get('fountain')
+    flatConfigs = _.flatten(configs)
+    completeConfig = {}
+    _.each flatConfigs, (config) =>
+      _.extend(completeConfig, config)
+    jsonConfig = JSON.stringify(completeConfig, null, 1)
+
+    writeConfigFile = () =>
+      return new Promise (resolve, reject) =>
+        fs.writeFile(configPath, jsonConfig, resolve)
+
+    return writeConfigFile().then () => Promise.resolve(completeConfig)
+
+module.exports = PdfConfigGenerator

--- a/lib/fountain-pdf-converter.coffee
+++ b/lib/fountain-pdf-converter.coffee
@@ -1,8 +1,11 @@
 {BufferedNodeProcess} = require 'atom'
 fs = require 'fs'
 path = require 'path'
+PdfConfigGenerator = require './fountain-pdf-config-generator.coffee'
 
 class PdfConverter
+
+  configGenerator = new PdfConfigGenerator()
 
   createPreview: (projectPath, fileText) ->
     @initiateConversion(projectPath, fileText, true)
@@ -76,6 +79,7 @@ class PdfConverter
       return Promise.resolve(outputFullPath)
 
     return notifyBegin()
+      .then(configGenerator.createConfig)
       .then(writeTempFile)
       .then(generatePdf)
       .then(notifySuccess)

--- a/lib/fountain.coffee
+++ b/lib/fountain.coffee
@@ -15,6 +15,126 @@ isFountainPreviewView = (object) ->
   object instanceof FountainPreviewView
 
 module.exports = Fountain =
+
+  config:
+    settings1:
+      title: "General"
+      type: 'object'
+      properties:
+        print_title_page:
+          type: "boolean"
+          'default': true
+          title: "Print title page"
+          description: "Whether title page should be included in pdf"
+        show_page_numbers:
+          type: "boolean"
+          'default': true
+          title: "Show page numbers"
+          description: "Whether page numbers will be rendered on each page"
+        print_profile:
+          type: "string"
+          enum: ['a4', 'usletter']
+          'default': 'usletter'
+          title: "Print profile"
+          description: "Specify the size of paper for printing pdf"
+    settings2:
+      title: "Text"
+      type: 'object'
+      properties:
+        embolden_scene_headers:
+          type: "boolean"
+          'default': true
+          title: "Embolden scene headers"
+          description: "Whether scene headers will be rendered in bold font"
+        print_sections:
+          type: "boolean"
+          'default': true
+          title: "Print sections"
+          description: "Whether to render sections in pdf (marked with #)"
+        print_synopsis:
+          type: "boolean"
+          'default': true
+          title: "Print synopses"
+          description: "Whether to render synopses in pdf (marked with =)"
+        print_actions:
+          type: "boolean"
+          'default': true
+          title: "Print actions"
+          description: "Whether to render action blocks in pdf"
+        print_headers:
+          type: "boolean"
+          'default': true
+          title: "Print headers"
+          description: "Whether to render scene headers in pdf"
+        print_dialogues:
+          type: "boolean"
+          'default': true
+          title: "Print dialogues"
+          description: "Whether to render dialogues in pdf"
+        print_notes:
+          type: "boolean"
+          'default': false
+          title: "Print notes"
+          description: "Whether to render notes in pdf"
+    settings3:
+      title: "Numbering"
+      type: 'object'
+      properties:
+        number_sections:
+          type: "boolean"
+          'default': false
+          title: "Number sections"
+          description: "Whether to auto-number sections in pdf"
+        scenes_numbers:
+          type: "string"
+          enum: ['none', 'left', 'right', 'both']
+          'default': 'none'
+          title: "Scene numbers"
+          description: "Specify position of scene auto-numbering in pdf"
+    settings4:
+      title: "Spacing"
+      type: 'object'
+      properties:
+        use_dual_dialogue:
+          type: "boolean"
+          'default': false
+          title: "Dual dialogue"
+          description: "Whether concurrent dialogue should be shown side by side"
+        each_scene_on_new_page:
+          type: "boolean"
+          'default': false
+          title: "Each scene on new page"
+          description: "Whether to show each scene on new page in pdf"
+        split_dialogue:
+          type: "boolean"
+          'default': false
+          title: "Split dialogue"
+          description: "Whether to split dialogue between pages or not in pdf"
+        double_space_between_scenes:
+          type: "boolean"
+          'default': true
+          title: "Double space between scenes"
+          description: "Whether a double space should be inserted between scenes in pdf"
+    settings5:
+      title: "Custom"
+      type: 'object'
+      properties:
+        print_header:
+          type: "string"
+          'default': ""
+          title: "Header"
+          description: "A text to put on the top of the page"
+        print_footer:
+          type: "string"
+          'default': ""
+          title: "Footer"
+          description: "A text to put on the bottom of the page"
+        print_watermark:
+          type: "string"
+          'default': ""
+          title: "Watermark"
+          description: "Watermark text to be shown on the page"
+
   subscriptions: null
 
   activate: (state) ->

--- a/spec/fountain-pdf-config-generator-spec.coffee
+++ b/spec/fountain-pdf-config-generator-spec.coffee
@@ -1,0 +1,88 @@
+PdfConfigGenerator = require '../lib/fountain-pdf-config-generator'
+fs = require 'fs'
+path = require 'path'
+
+describe 'Fountain PDF Config Generator', ->
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage 'fountain'
+
+  # sanity checks
+  it 'should have loaded fountain package', ->
+    expect(atom.packages.isPackageActive('fountain')).toBeTruthy()
+
+
+  describe 'setting/writing package settings configs', ->
+
+    flag = false
+    config = null
+
+    beforeEach ->
+      flag = false
+      @configGenerator = new PdfConfigGenerator()
+      config = {
+       "print_title_page": false,
+       "print_profile": "a4",
+       "print_watermark": "BOOP"
+      }
+
+    it 'should be able to set string', ->
+      section = 'settings5'
+      property = 'print_watermark'
+
+      atom.config.set('fountain.'+section+'.'+property, config[property])
+      retVal = null
+
+      runs () ->
+        @configGenerator.createConfig().then (data) =>
+          retVal = data
+          flag = true
+      , 5000
+
+      waitsFor () ->
+        return flag
+      , "flag set", 3000
+
+      runs () ->
+        expect(retVal[property]).toEqual(config[property])
+
+    it 'should be able to set enum', ->
+      section = 'settings1'
+      property = 'print_profile'
+
+      atom.config.set('fountain.'+section+'.'+property, config[property])
+      retVal = null
+
+      runs () ->
+        @configGenerator.createConfig().then (data) =>
+          retVal = data
+          flag = true
+      , 5000
+
+      waitsFor () ->
+        return flag
+      , "flag set", 3000
+
+      runs () ->
+        expect(retVal[property]).toEqual(config[property])
+
+    it 'should be able to set boolean', ->
+      section = 'settings1'
+      property = 'print_title_page'
+
+      atom.config.set('fountain.'+section+'.'+property, config[property])
+      retVal = null
+
+      runs () ->
+        @configGenerator.createConfig().then (data) =>
+          retVal = data
+          flag = true
+      , 5000
+
+      waitsFor () ->
+        return flag
+      , "flag set", 3000
+
+      runs () ->
+        expect(retVal[property]).toEqual(config[property])


### PR DESCRIPTION
A satisfying addition.  Establishes settings menu under the Fountain package.  Offers all of the afterwriting configurations for end users to modify (except "Snippets").  Writes a new JSON config file on the fly, directly from the users current settings, before rendering.  Hooked in as a support module for PDF converter.