### PR TITLE
Remove onDidSave fn registration for PDF Preview

### DIFF
--- a/lib/fountain.coffee
+++ b/lib/fountain.coffee
@@ -208,8 +208,7 @@ module.exports = Fountain =
       text = activeEditor.getSelectedText() || activeEditor.getText()
       pdfConverter = new PdfConverter()
       pdfConverter.createPreview((if event then event.path else activeEditorPath), text).then (uri) =>
-        atom.workspace.open(uri, {"searchAllPanes":true})
-        if !event then activeEditor.onDidSave(this.pdfPreview)
+        atom.workspace.open(uri, {searchAllPanes:true})
     else
       atom.notifications.addInfo("No fountain file is currently targeted")
 


### PR DESCRIPTION
To make onDidSave work properly, the following is necessary:
    Get the disposable from onDidSave below and store on the proper scope...
    (probably map[uri] = disposable or something)
Then:      
    Prior to generating and opening pdf...
      If preview fn called by onDidSave, but no existent preview...
        Call dispose() on the disposable to cancel the callback

I walked this path a little to see where it would lead... and ran into too many problems to justify.  It could be done, but we'd have to decide how that would be done.  May involve some refactor.  May involve additional package config settings.

If we go the route of this pull request, then we lose (maybe just temporarily) the automatic-regeneration of the PDF on save events to the fountain file.  However, we solve both the UX issue and the legit bug.

1. Halts the automatic reopening of PDF Preview on fountain save after closing out of preview. (bug)
2. Defaults to manual generation, meaning PDF Preview only takes focus when users are actively engaging it. (ux issue)
        