### PR TITLE
Fix Toggle Outline View in the Packages menu (#24)

### DIFF
--- a/menus/fountain.cson
+++ b/menus/fountain.cson
@@ -10,7 +10,7 @@
       'submenu': [
         {
           'label': 'Toggle Outline View'
-          'command': 'fountain:toggleOutlineView'
+          'command': 'fountain:toggle-outline-view'
         }
         {
           'label': 'Show Preview'


### PR DESCRIPTION
I noticed under the Packages -> Fountain menu that Toggle Outline View doesn't do anything, and doesn't have a keyboard shortcut listed next to it. This should fix that. (And I ran the tests!)